### PR TITLE
Scaffold LOGOS FastAPI project

### DIFF
--- a/logos/app.py
+++ b/logos/app.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/ingest/preview")
+def ingest_preview() -> dict[str, str]:
+    """Return a simple status payload for preview."""
+    return {"status": "ok"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "logos"
+version = "0.1.0"
+description = "LOGOS FastAPI project"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "httpx",
+]
+
+[tool.ruff]
+line-length = 88
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/tests/test_ingest_preview.py
+++ b/tests/test_ingest_preview.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from logos.app import app
+
+
+client = TestClient(app)
+
+
+def test_ingest_preview() -> None:
+    response = client.get("/ingest/preview")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- scaffold LOGOS FastAPI app with ingest preview endpoint
- configure project metadata and tooling in pyproject
- add tests for ingest preview route

## Testing
- `ruff check logos tests`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b008cd3ce483478b8232f8eb65415a