### PR TITLE
Add search endpoint backed by Neo4j full-text index

### DIFF
--- a/logos/main.py
+++ b/logos/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException
 
 from .graphio.upsert import upsert_interaction
+from .graphio.neo4j_client import run_query
 
 app = FastAPI()
 PREVIEW_CACHE: dict[str, str] = {}
@@ -13,3 +14,25 @@ async def commit(interaction_id: str) -> dict[str, str]:
         raise HTTPException(status_code=404, detail="Preview not found")
     upsert_interaction(interaction_id, preview)
     return {"status": "committed"}
+
+
+@app.get("/search")
+async def search(q: str) -> list[dict[str, object]]:
+    results = run_query(
+        (
+            "CALL db.index.fulltext.queryNodes('logos_name_idx', $q) "
+            "YIELD node, score "
+            "RETURN labels(node) AS labels, node.id AS id, node.name AS name, score "
+            "ORDER BY score DESC LIMIT 10"
+        ),
+        {"q": q},
+    )
+    return [
+        {
+            "labels": r["labels"],
+            "id": r["id"],
+            "name": r["name"],
+            "score": r["score"],
+        }
+        for r in results
+    ]

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -1,0 +1,32 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from logos import main
+
+
+def test_search_endpoint_returns_results(monkeypatch):
+    client = TestClient(main.app)
+
+    fake_results = [
+        {"labels": ["Person"], "id": "p1", "name": "Alice", "score": 0.9},
+        {"labels": ["Org"], "id": "o1", "name": "Acme", "score": 0.8},
+    ]
+
+    captured = {}
+
+    def fake_run_query(query, params):
+        captured["query"] = query
+        captured["params"] = params
+        return fake_results
+
+    monkeypatch.setattr(main, "run_query", fake_run_query)
+
+    response = client.get("/search?q=test")
+    assert response.status_code == 200
+    assert response.json() == fake_results
+    assert "logos_name_idx" in captured["query"]
+    assert captured["params"] == {"q": "test"}


### PR DESCRIPTION
## Summary
- add GET /search endpoint querying Neo4j full-text index `logos_name_idx`
- return matched node info with labels and score
- test search endpoint with stubbed `run_query`

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b01d9f86e48347bafc868031ab9a3a