### PR TITLE
Add ego graph endpoint and tests

### DIFF
--- a/tests/test_graph_endpoint.py
+++ b/tests/test_graph_endpoint.py
@@ -1,0 +1,30 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from logos import main
+
+
+def test_ego_graph_returns_expected_keys(monkeypatch):
+    client = TestClient(main.app)
+
+    fake_result = [
+        {
+            "pnodes": [{"id": "p1"}],
+            "nodes": [{"id": "p2"}],
+            "edges": [{"source": "p1", "target": "p2", "type": "KNOWS"}],
+        }
+    ]
+
+    def fake_run_query(query, params):
+        return fake_result
+
+    monkeypatch.setattr(main, "run_query", fake_run_query)
+
+    response = client.get("/graph/ego", params={"person_id": "p1"})
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data.keys()) == {"pnodes", "nodes", "edges"}


### PR DESCRIPTION
## Summary
- add `/graph/ego` endpoint to return a person's 1-hop network
- test ego graph endpoint response shape

## Testing
- `ruff check logos tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b01effefc883478931e8f9c585324c