### PR TITLE
Add alerts endpoint with cached dependency setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+
+.cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Fortsecue
 For Fortescue related diagrams and code
+
+## Development
+
+Run `./setup.sh` to install dependencies and run lint/tests. The script hashes
+`requirements.txt` (and other dependency files) and caches the installed
+packages under `.cache/`. When the hash hasn't changed, the install step is
+skipped, speeding up repeated runs.

--- a/logos/main.py
+++ b/logos/main.py
@@ -59,3 +59,48 @@ async def ego_graph(person_id: str) -> dict[str, list[dict[str, object]]]:
         "nodes": row.get("nodes", []),
         "edges": row.get("edges", []),
     }
+
+
+@app.get("/alerts")
+async def alerts() -> dict[str, list[dict[str, object]]]:
+    unresolved_results = run_query(
+        (
+            "MATCH (c:Commitment)<-[:MADE]-(p:Person) "
+            "WHERE c.status NOT IN ['accepted', 'done'] "
+            "AND c.due_date < date() - duration('P7D') "
+            "RETURN c.id AS id, c.description AS description, "
+            "c.due_date AS due_date, c.status AS status, "
+            "p.id AS person_id, p.name AS person_name"
+        )
+    )
+    unresolved = [
+        {
+            "id": r["id"],
+            "description": r.get("description"),
+            "due_date": r.get("due_date"),
+            "status": r.get("status"),
+            "person_id": r.get("person_id"),
+            "person_name": r.get("person_name"),
+        }
+        for r in unresolved_results
+    ]
+
+    sentiment_results = run_query(
+        (
+            "MATCH (o:Org)<-[:WORKS_FOR]-(p:Person)<-[:MENTIONS]-(i:Interaction) "
+            "WHERE i.date >= date() - duration('P14D') "
+            "WITH o, i ORDER BY i.date DESC "
+            "WITH o, collect(i.sentiment)[0..3] AS last3 "
+            "WHERE size(last3) = 3 AND all(s IN last3 WHERE s = 'negative') "
+            "RETURN o.id AS org_id, o.name AS org_name"
+        )
+    )
+    sentiment = [
+        {"org_id": r["org_id"], "org_name": r["org_name"]}
+        for r in sentiment_results
+    ]
+
+    return {
+        "unresolved_commitments": unresolved,
+        "sentiment_drop": sentiment,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.116.1
+httpx==0.28.1
+pytest==8.4.1
+ruff==0.12.7

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILES=""
+[[ -f pyproject.toml ]] && FILES="$FILES pyproject.toml"
+for f in requirements*.txt; do
+  [[ -e "$f" ]] && FILES="$FILES $f"
+done
+[[ -f uv.lock ]] && FILES="$FILES uv.lock"
+[[ -f poetry.lock ]] && FILES="$FILES poetry.lock"
+
+if [[ -n "$FILES" ]]; then
+  HASH=$(cat $FILES | sha256sum | cut -d' ' -f1)
+else
+  HASH="no-deps"
+fi
+
+STAMP=".cache/deps.${HASH}.stamp"
+if [[ -f "$STAMP" ]]; then
+  echo "Dependencies up to date (hash $HASH), skipping installation"
+else
+  echo "Installing dependencies (hash $HASH)"
+  mkdir -p .cache
+  rm -f .cache/deps.*.stamp
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install --system -r requirements.txt
+  else
+    pip install -r requirements.txt
+  fi
+  touch "$STAMP"
+fi
+
+ruff check .
+python -m pytest

--- a/tests/test_alerts_endpoint.py
+++ b/tests/test_alerts_endpoint.py
@@ -1,0 +1,48 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from logos import main
+
+
+def test_alerts_lists(monkeypatch):
+    client = TestClient(main.app)
+    calls: list[str] = []
+
+    def fake_run_query(query, params=None):  # type: ignore[unused-argument]
+        calls.append(query)
+        if "Commitment" in query:
+            return [
+                {
+                    "id": "c1",
+                    "description": "desc",
+                    "due_date": "2024-01-01",
+                    "status": "pending",
+                    "person_id": "p1",
+                    "person_name": "Alice",
+                }
+            ]
+        return [{"org_id": "o1", "org_name": "Acme"}]
+
+    monkeypatch.setattr(main, "run_query", fake_run_query)
+
+    response = client.get("/alerts")
+    assert response.status_code == 200
+    assert response.json() == {
+        "unresolved_commitments": [
+            {
+                "id": "c1",
+                "description": "desc",
+                "due_date": "2024-01-01",
+                "status": "pending",
+                "person_id": "p1",
+                "person_name": "Alice",
+            }
+        ],
+        "sentiment_drop": [{"org_id": "o1", "org_name": "Acme"}],
+    }
+    assert "MATCH (c:Commitment" in calls[0]
+    assert "collect(i.sentiment)[0..3]" in calls[1]


### PR DESCRIPTION
## Summary
- implement `/alerts` API to report unresolved commitments and organisations with recent negative interactions
- add tests stubbing `run_query` for alerts endpoint
- add `setup.sh` that hashes dependency files and skips reinstalling unchanged deps
- commit pinned `requirements.txt` and document cache behavior

## Testing
- `./setup.sh`
- `./setup.sh` (cached)


------
https://chatgpt.com/codex/tasks/task_b_68b020ceced883479f6ed6288f305e20