### PR TITLE
Add audio ingest endpoint

### DIFF
--- a/logos/main.py
+++ b/logos/main.py
@@ -1,10 +1,28 @@
-from fastapi import FastAPI, HTTPException
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException, UploadFile, File
 
 from .graphio.upsert import upsert_interaction
 from .graphio.neo4j_client import run_query
 
 app = FastAPI()
 PREVIEW_CACHE: dict[str, str] = {}
+
+
+def _store_preview(preview: str) -> dict[str, str]:
+    """Store preview text and return a new interaction id."""
+    interaction_id = str(uuid4())
+    PREVIEW_CACHE[interaction_id] = preview
+    return {"interaction_id": interaction_id, "preview": preview}
+
+
+@app.post("/ingest/audio")
+async def ingest_audio(file: UploadFile = File(...)) -> dict[str, str]:
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=400, detail="Empty file")
+    preview = "transcribed"
+    return _store_preview(preview)
 
 
 @app.post("/commit/{interaction_id}")

--- a/tests/test_ingest_audio.py
+++ b/tests/test_ingest_audio.py
@@ -1,0 +1,24 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import asyncio
+import httpx
+
+from logos import main
+
+
+def test_ingest_audio_stores_preview():
+    async def _run() -> httpx.Response:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=main.app), base_url="http://test"
+        ) as client:
+            files = {"file": ("test.wav", b"0" * 4, "audio/wav")}
+            return await client.post("/ingest/audio", files=files)
+
+    response = asyncio.run(_run())
+    assert response.status_code == 200
+    data = response.json()
+    assert data["preview"] == "transcribed"
+    assert main.PREVIEW_CACHE[data["interaction_id"]] == "transcribed"


### PR DESCRIPTION
## Summary
- support uploading audio files via `/ingest/audio` and stub transcription
- add coverage for audio ingestion using httpx

## Testing
- `ruff check logos tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b0254a0a808347b7e6370be68dc0e6