### PR TITLE
test: check audio preview cache for mp3 and wav

### DIFF
--- a/tests/test_ingest_audio.py
+++ b/tests/test_ingest_audio.py
@@ -5,16 +5,21 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import asyncio
 import httpx
+import pytest
 
 from logos import main
 
 
-def test_ingest_audio_stores_preview():
+@pytest.mark.parametrize(
+    ("filename", "mimetype"),
+    [("test.wav", "audio/wav"), ("test.mp3", "audio/mpeg")],
+)
+def test_ingest_audio_stores_preview(filename: str, mimetype: str) -> None:
     async def _run() -> httpx.Response:
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=main.app), base_url="http://test"
         ) as client:
-            files = {"file": ("test.wav", b"0" * 4, "audio/wav")}
+            files = {"file": (filename, b"0" * 4, mimetype)}
             return await client.post("/ingest/audio", files=files)
 
     response = asyncio.run(_run())


### PR DESCRIPTION
## Summary
- parameterize audio ingestion test to handle mp3 and wav uploads
- verify preview is stored in cache for both file types

## Testing
- `ruff check logos tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b02837929c8347a6063f03a99eaf5b