### PR TITLE
Validate audio MIME type in ingest endpoint

### DIFF
--- a/logos/main.py
+++ b/logos/main.py
@@ -18,6 +18,8 @@ def _store_preview(preview: str) -> dict[str, str]:
 
 @app.post("/ingest/audio")
 async def ingest_audio(file: UploadFile = File(...)) -> dict[str, str]:
+    if not file.content_type.startswith("audio/"):
+        raise HTTPException(status_code=400, detail="Invalid audio type")
     data = await file.read()
     if not data:
         raise HTTPException(status_code=400, detail="Empty file")


### PR DESCRIPTION
## Summary
- ensure `/ingest/audio` rejects non-audio uploads

## Testing
- `ruff check logos tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b028357c8483478bcdf599cb2bb366