### PR TITLE
Add preview extraction for document ingestion

### DIFF
--- a/logos/app.py
+++ b/logos/app.py
@@ -1,1 +1,1 @@
-from .main import app
+from .main import app  # noqa: F401

--- a/tests/test_commit_endpoint.py
+++ b/tests/test_commit_endpoint.py
@@ -10,7 +10,7 @@ from logos import main
 
 def test_commit_endpoint_writes_preview(monkeypatch):
     client = TestClient(main.app)
-    main.PREVIEW_CACHE["i1"] = "hello"
+    main.PREVIEWS["i1"] = {"interaction": {"summary": "hello"}}
 
     called = {}
 

--- a/tests/test_ingest_audio.py
+++ b/tests/test_ingest_audio.py
@@ -25,5 +25,5 @@ def test_ingest_audio_stores_preview(filename: str, mimetype: str) -> None:
     response = asyncio.run(_run())
     assert response.status_code == 200
     data = response.json()
-    assert data["preview"] == "transcribed"
-    assert main.PREVIEW_CACHE[data["interaction_id"]] == "transcribed"
+    assert data["preview"]["interaction"]["summary"] == "transcribed"
+    assert main.PREVIEWS[data["interaction_id"]] == data["preview"]

--- a/tests/test_ingest_doc.py
+++ b/tests/test_ingest_doc.py
@@ -1,0 +1,31 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import asyncio
+import httpx
+
+from logos import main
+
+
+def test_ingest_doc_extracts_entities() -> None:
+    text = "Jane Smith will send the report to Acme Pty Ltd by 2023-09-30."
+
+    async def _run() -> httpx.Response:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=main.app), base_url="http://test"
+        ) as client:
+            return await client.post(
+                "/ingest/doc", json={"source_uri": "file://example", "text": text}
+            )
+
+    response = asyncio.run(_run())
+    assert response.status_code == 200
+    data = response.json()
+    preview = data["preview"]
+    assert data["interaction_id"]
+    assert len(preview["entities"]["orgs"]) >= 1
+    assert len(preview["entities"]["persons"]) >= 1
+    assert len(preview["entities"]["commitments"]) >= 1
+    assert main.PREVIEWS[data["interaction_id"]] == preview


### PR DESCRIPTION
## Summary
- extend document ingestion to accept source URI and build entity preview
- store previews in-memory for commit and other endpoints
- cover ingestion and commit behaviour with tests

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b10fcb67488347b0281ea98faccd0f