### PR TITLE
chore(deps): add python-multipart for FastAPI uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Fortsecue
 For Fortescue related diagrams and code
 
+## Dependencies
+
+- fastapi
+- httpx
+- pytest
+- python-multipart
+- ruff
+
 ## Development
 
 Run `./setup.sh` to install dependencies and run lint/tests. The script hashes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.116.1
 httpx==0.28.1
 pytest==8.4.1
+python-multipart==0.0.9
 ruff==0.12.7


### PR DESCRIPTION
## Summary
- add python-multipart dependency
- document dependencies in README

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b155b07a208347957643084ee74d53