### PR TITLE
Use portable fulltext index creation and capture interaction details

### DIFF
--- a/logos/graphio/neo4j_client.py
+++ b/logos/graphio/neo4j_client.py
@@ -38,7 +38,7 @@ def ensure_indexes() -> None:
             f"CREATE CONSTRAINT {label.lower()}_id IF NOT EXISTS FOR (n:{label}) REQUIRE n.id IS UNIQUE"
         )
     run_query(
-        "CREATE FULLTEXT INDEX logos_name_idx IF NOT EXISTS FOR (n:Person|Org|Project|Contract|Commitment|Interaction) ON EACH [n.name]"
+        "CALL db.index.fulltext.createNodeIndex('logos_name_idx', ['Person','Org','Project','Contract','Commitment'], ['name'], { ifNotExists: true })"
     )
 
 

--- a/logos/graphio/upsert.py
+++ b/logos/graphio/upsert.py
@@ -23,14 +23,32 @@ def upsert_person(person_id: str, name: str, org_id: Optional[str] = None) -> No
 
 def upsert_interaction(
     interaction_id: str,
-    preview: str,
+    type_: str,
+    at: str,
+    sentiment: float,
+    summary: str,
+    source_uri: str,
     mention_person_ids: Optional[Sequence[str]] = None,
 ) -> None:
     """Upsert an Interaction node and optional MENTIONS relations."""
-    query = "MERGE (i:Interaction {id: $id}) SET i.preview = $preview"
-    params = {"id": interaction_id, "preview": preview}
+    query = (
+        "MERGE (i:Interaction {id: $id}) "
+        "SET i.type=$type, i.at=datetime($at), i.sentiment=$sentiment, "
+        "i.summary=$summary, i.source_uri=$source_uri, i.last_seen=datetime()"
+    )
+    params = {
+        "id": interaction_id,
+        "type": type_,
+        "at": at,
+        "sentiment": sentiment,
+        "summary": summary,
+        "source_uri": source_uri,
+    }
     if mention_person_ids:
-        query += " WITH i UNWIND $mention_ids AS mid MERGE (p:Person {id: mid}) MERGE (i)-[:MENTIONS]->(p)"
+        query += (
+            " WITH i UNWIND $mention_ids AS mid MERGE (p:Person {id: mid}) "
+            "MERGE (i)-[:MENTIONS]->(p)"
+        )
         params["mention_ids"] = list(mention_person_ids)
     run_query(query, params)
 

--- a/logos/main.py
+++ b/logos/main.py
@@ -79,7 +79,15 @@ async def commit(interaction_id: str) -> dict[str, str]:
     preview = PREVIEWS.get(interaction_id)
     if preview is None:
         raise HTTPException(status_code=404, detail="Preview not found")
-    upsert_interaction(interaction_id, preview["interaction"]["summary"])
+    interaction = preview["interaction"]
+    upsert_interaction(
+        interaction_id,
+        interaction["type"],
+        interaction["at"],
+        interaction["sentiment"],
+        interaction["summary"],
+        interaction["source_uri"],
+    )
     return {"status": "committed"}
 
 

--- a/tests/test_commit_endpoint.py
+++ b/tests/test_commit_endpoint.py
@@ -10,16 +10,37 @@ from logos import main
 
 def test_commit_endpoint_writes_preview(monkeypatch):
     client = TestClient(main.app)
-    main.PREVIEWS["i1"] = {"interaction": {"summary": "hello"}}
+    main.PREVIEWS["i1"] = {
+        "interaction": {
+            "type": "email",
+            "at": "2024-01-01T00:00:00",
+            "sentiment": 0.0,
+            "summary": "hello",
+            "source_uri": "uri",
+        }
+    }
 
     called = {}
 
-    def fake_upsert(interaction_id, preview):
+    def fake_upsert(interaction_id, type_, at, sentiment, summary, source_uri, mention_ids=None):
         called["interaction_id"] = interaction_id
-        called["preview"] = preview
+        called["type"] = type_
+        called["at"] = at
+        called["sentiment"] = sentiment
+        called["summary"] = summary
+        called["source_uri"] = source_uri
+        called["mention_ids"] = mention_ids
 
     monkeypatch.setattr(main, "upsert_interaction", fake_upsert)
     response = client.post("/commit/i1")
 
     assert response.status_code == 200
-    assert called == {"interaction_id": "i1", "preview": "hello"}
+    assert called == {
+        "interaction_id": "i1",
+        "type": "email",
+        "at": "2024-01-01T00:00:00",
+        "sentiment": 0.0,
+        "summary": "hello",
+        "source_uri": "uri",
+        "mention_ids": None,
+    }

--- a/tests/test_neo4j_client.py
+++ b/tests/test_neo4j_client.py
@@ -22,7 +22,7 @@ def test_ensure_indexes_calls_expected_cypher(monkeypatch):
         "CREATE CONSTRAINT contract_id IF NOT EXISTS FOR (n:Contract) REQUIRE n.id IS UNIQUE",
         "CREATE CONSTRAINT commitment_id IF NOT EXISTS FOR (n:Commitment) REQUIRE n.id IS UNIQUE",
         "CREATE CONSTRAINT interaction_id IF NOT EXISTS FOR (n:Interaction) REQUIRE n.id IS UNIQUE",
-        "CREATE FULLTEXT INDEX logos_name_idx IF NOT EXISTS FOR (n:Person|Org|Project|Contract|Commitment|Interaction) ON EACH [n.name]",
+        "CALL db.index.fulltext.createNodeIndex('logos_name_idx', ['Person','Org','Project','Contract','Commitment'], ['name'], { ifNotExists: true })",
     ]
 
     assert calls == expected

--- a/tests/test_upsert.py
+++ b/tests/test_upsert.py
@@ -43,12 +43,28 @@ def test_upsert_interaction_mentions(monkeypatch):
         captured["params"] = params
 
     monkeypatch.setattr(upsert, "run_query", fake_run_query)
-    upsert.upsert_interaction("i1", "hello", ["p1", "p2"])
+    upsert.upsert_interaction(
+        "i1",
+        "email",
+        "2024-01-01T00:00:00",
+        0.1,
+        "hello",
+        "uri",
+        ["p1", "p2"],
+    )
     assert (
         captured["query"]
-        == "MERGE (i:Interaction {id: $id}) SET i.preview = $preview WITH i UNWIND $mention_ids AS mid MERGE (p:Person {id: mid}) MERGE (i)-[:MENTIONS]->(p)"
+        == "MERGE (i:Interaction {id: $id}) SET i.type=$type, i.at=datetime($at), i.sentiment=$sentiment, i.summary=$summary, i.source_uri=$source_uri, i.last_seen=datetime() WITH i UNWIND $mention_ids AS mid MERGE (p:Person {id: mid}) MERGE (i)-[:MENTIONS]->(p)"
     )
-    assert captured["params"] == {"id": "i1", "preview": "hello", "mention_ids": ["p1", "p2"]}
+    assert captured["params"] == {
+        "id": "i1",
+        "type": "email",
+        "at": "2024-01-01T00:00:00",
+        "sentiment": 0.1,
+        "summary": "hello",
+        "source_uri": "uri",
+        "mention_ids": ["p1", "p2"],
+    }
 
 
 def test_upsert_commitment(monkeypatch):


### PR DESCRIPTION
## Summary
- replace raw fulltext index DDL with `db.index.fulltext.createNodeIndex` for portability
- upsert `Interaction` nodes with type, timestamp, sentiment, summary, source URI, and optional mentions
- adjust commit endpoint and tests for expanded interaction schema

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b159bd8fa48347b4f770ae47e9c87f