### PR TITLE
feat: add graph and search endpoints

### DIFF
--- a/tests/test_graph_endpoint.py
+++ b/tests/test_graph_endpoint.py
@@ -15,7 +15,7 @@ def test_ego_graph_returns_expected_keys(monkeypatch):
         {
             "pnodes": [{"id": "p1"}],
             "nodes": [{"id": "p2"}],
-            "edges": [{"source": "p1", "target": "p2", "type": "KNOWS"}],
+            "edges": [{"src": "p1", "dst": "p2", "rel": "KNOWS"}],
         }
     ]
 
@@ -28,3 +28,4 @@ def test_ego_graph_returns_expected_keys(monkeypatch):
     assert response.status_code == 200
     data = response.json()
     assert set(data.keys()) == {"pnodes", "nodes", "edges"}
+    assert data["edges"] == [{"src": "p1", "dst": "p2", "rel": "KNOWS"}]

--- a/tests/test_search_endpoint.py
+++ b/tests/test_search_endpoint.py
@@ -12,8 +12,8 @@ def test_search_endpoint_returns_results(monkeypatch):
     client = TestClient(main.app)
 
     fake_results = [
-        {"labels": ["Person"], "id": "p1", "name": "Alice", "score": 0.9},
-        {"labels": ["Org"], "id": "o1", "name": "Acme", "score": 0.8},
+        {"labels": ["Person"], "props": {"id": "p1", "name": "Alice"}, "score": 0.9},
+        {"labels": ["Org"], "props": {"id": "o1", "name": "Acme"}, "score": 0.8},
     ]
 
     captured = {}
@@ -27,6 +27,9 @@ def test_search_endpoint_returns_results(monkeypatch):
 
     response = client.get("/search?q=test")
     assert response.status_code == 200
-    assert response.json() == fake_results
+    assert response.json() == [
+        {"id": "p1", "name": "Alice", "labels": ["Person"], "_score": 0.9},
+        {"id": "o1", "name": "Acme", "labels": ["Org"], "_score": 0.8},
+    ]
     assert "logos_name_idx" in captured["query"]
     assert captured["params"] == {"q": "test"}


### PR DESCRIPTION
## Summary
- return node props and score from /search using fulltext index
- expose one-hop ego graph at /graph/ego with src/rel/dst edges
- surface unresolved commitments and sentiment drops via /alerts

## Testing
- `ruff check logos tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b15ceaf9408347b5b7ae7809de1b48