### PR TITLE
chore(graph): graceful 503s and /health when Neo4j unavailable

### DIFF
--- a/logos/graphio/neo4j_client.py
+++ b/logos/graphio/neo4j_client.py
@@ -6,25 +6,38 @@ try:
 except Exception:  # pragma: no cover - neo4j is optional for tests
     GraphDatabase = None  # type: ignore
 
+
+class GraphUnavailable(Exception):
+    """Raised when the graph database is unavailable."""
+
+
 NEO4J_URI = os.getenv("NEO4J_URI")
 NEO4J_USER = os.getenv("NEO4J_USER")
 NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD")
 
 _driver = None
 if GraphDatabase and NEO4J_URI and NEO4J_USER and NEO4J_PASSWORD:
-    _driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
+    try:
+        _driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD))
+    except Exception:  # pragma: no cover - unreachable without neo4j
+        _driver = None
 
 
 def run_query(query: str, params: Optional[Dict[str, Any]] = None) -> Any:
     """Run a Cypher query against the configured Neo4j instance."""
     if _driver is None:
-        raise RuntimeError("Neo4j driver not configured")
-    with _driver.session() as session:
-        return session.run(query, params or {})
+        raise GraphUnavailable("neo4j_unavailable")
+    try:
+        with _driver.session() as session:
+            return session.run(query, params or {})
+    except Exception as exc:  # pragma: no cover - network failure etc.
+        raise GraphUnavailable("neo4j_unavailable") from exc
 
 
 def ensure_indexes() -> None:
     """Ensure required constraints and indexes exist."""
+    if _driver is None:
+        return
     labels = [
         "Person",
         "Org",
@@ -42,8 +55,19 @@ def ensure_indexes() -> None:
     )
 
 
-if _driver is not None:
+def ping() -> Dict[str, Any]:
+    """Return the availability of the graph database."""
+    if _driver is None:
+        return {"ok": False, "reason": "neo4j_unavailable"}
     try:
+        run_query("RETURN 1")
+        return {"ok": True, "reason": "neo4j_up"}
+    except GraphUnavailable:
+        return {"ok": False, "reason": "neo4j_unavailable"}
+
+
+if _driver is not None:
+    try:  # pragma: no cover - executed on import
         ensure_indexes()
     except Exception:
         # Index creation failure shouldn't block application start

--- a/tests/test_graph_unavailable.py
+++ b/tests/test_graph_unavailable.py
@@ -1,0 +1,46 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from logos import main
+from logos.graphio import neo4j_client
+
+
+def _down(monkeypatch):
+    monkeypatch.setattr(neo4j_client, "_driver", None)
+
+
+def test_health_reports_down_when_no_driver(monkeypatch):
+    _down(monkeypatch)
+    client = TestClient(main.app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"neo4j": "down", "reason": "neo4j_unavailable"}
+
+
+def test_commit_returns_503_when_graph_down(monkeypatch):
+    _down(monkeypatch)
+    client = TestClient(main.app)
+    main.PREVIEWS["i1"] = {
+        "interaction": {
+            "type": "email",
+            "at": "2024-01-01T00:00:00",
+            "sentiment": 0.0,
+            "summary": "hello",
+            "source_uri": "uri",
+        }
+    }
+    resp = client.post("/commit/i1")
+    assert resp.status_code == 503
+    assert resp.json() == {"error": "neo4j_unavailable"}
+
+
+def test_search_returns_503_when_graph_down(monkeypatch):
+    _down(monkeypatch)
+    client = TestClient(main.app)
+    resp = client.get("/search?q=x")
+    assert resp.status_code == 503
+    assert resp.json() == {"error": "neo4j_unavailable"}

--- a/tests/test_neo4j_client.py
+++ b/tests/test_neo4j_client.py
@@ -13,6 +13,7 @@ def test_ensure_indexes_calls_expected_cypher(monkeypatch):
         calls.append(query)
 
     monkeypatch.setattr(neo4j_client, "run_query", fake_run_query)
+    monkeypatch.setattr(neo4j_client, "_driver", object())
     neo4j_client.ensure_indexes()
 
     expected = [


### PR DESCRIPTION
## Summary
- raise `GraphUnavailable` when Neo4j connection fails and expose `ping()` for health checks
- handle Neo4j outages in API routes and add `/health` endpoint
- cover Neo4j outages with tests for health, commit, and search

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b168c7943c8347a6f67b951f5ad3a3