### PR TITLE
Add shadow-mode meta-controller with activation graph routing

### DIFF
--- a/logos/app_state.py
+++ b/logos/app_state.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from logos.events.bus import create_event_bus_from_env
+from logos.meta.controller import MetaController
 from logos.knowledgebase.store import DEFAULT_BASE_PATH
 from logos.staging.store import LocalStagingStore
 
@@ -17,3 +18,19 @@ KB_PATH = Path(os.getenv("LOGOS_KB_DIR", str(DEFAULT_BASE_PATH)))
 
 
 EVENT_BUS = create_event_bus_from_env()
+
+
+EVENT_BUS_ENABLED = os.getenv("LOGOS_EVENT_BUS_ENABLED", "1").strip() not in {"0", "false", "False"}
+_META_CONTROLLER: MetaController | None = None
+
+
+def get_meta_controller() -> MetaController | None:
+    """Return a lazily initialised meta-controller when enabled."""
+
+    global _META_CONTROLLER
+    if not EVENT_BUS_ENABLED or not MetaController.is_enabled():
+        return None
+
+    if _META_CONTROLLER is None:
+        _META_CONTROLLER = MetaController(EVENT_BUS, config_path=KB_PATH / "rules" / "meta_controller.yml")
+    return _META_CONTROLLER

--- a/logos/knowledgebase/rules/meta_controller.yml
+++ b/logos/knowledgebase/rules/meta_controller.yml
@@ -1,0 +1,45 @@
+mode: shadow
+activation_threshold: 0.45
+
+experimentation:
+  learning_loop_mode: unified
+  alternatives:
+    - unified
+    - separate
+
+activation_graph:
+  seed: 19
+  damping: 0.85
+  propagation_steps: 2
+  noise_scale: 0.0
+  base_activation:
+    module.belief_prior_adjuster: 0.2
+    module.ontology_proposal_summariser: 0.2
+    module.learning_signal_router: 0.2
+  edges:
+    - from: module.belief_prior_adjuster
+      to: module.learning_signal_router
+      weight: 0.2
+    - from: module.ontology_proposal_summariser
+      to: module.learning_signal_router
+      weight: 0.25
+    - from: module.learning_signal_router
+      to: module.belief_prior_adjuster
+      weight: 0.15
+
+event_injection:
+  "*":
+    module.belief_prior_adjuster: 0.05
+  logos.pipeline.stage_completed:
+    module.learning_signal_router: 0.4
+  logos.ontology.candidate_detected:
+    module.ontology_proposal_summariser: 0.5
+  logos.feedback.received:
+    module.learning_signal_router: 0.35
+
+active_allowlist:
+  pipelines:
+    - pipeline.concept_update
+    - pipeline.reasoning_alerts
+  modules:
+    - module.learning_signal_router

--- a/logos/main.py
+++ b/logos/main.py
@@ -1,6 +1,7 @@
 # This module is part of LOGOS (local-first stakeholder intelligence).
 # It must follow the architecture and schema defined in the LOGOS docs (/docs).
 # Pipeline: ingest → transcribe → nlp_extract → normalise → graphio → ui.
+import asyncio
 import logging
 from datetime import datetime, timezone
 from uuid import uuid4
@@ -52,6 +53,40 @@ PENDING_INTERACTIONS: Dict[str, Dict[str, Any]] = app_state.PENDING_INTERACTIONS
 PREVIEWS = PENDING_INTERACTIONS
 STAGING_STORE = app_state.STAGING_STORE
 logger = logging.getLogger(__name__)
+META_CONTROLLER_TASK: asyncio.Task[None] | None = None
+META_CONTROLLER_STOP_EVENT: asyncio.Event | None = None
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    global META_CONTROLLER_TASK, META_CONTROLLER_STOP_EVENT
+    controller = app_state.get_meta_controller()
+    if controller is None:
+        return
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        logger.warning("meta_controller_startup_skipped_no_loop")
+        return
+
+    META_CONTROLLER_STOP_EVENT = asyncio.Event()
+    META_CONTROLLER_TASK = asyncio.create_task(controller.run_forever(META_CONTROLLER_STOP_EVENT))
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    global META_CONTROLLER_TASK, META_CONTROLLER_STOP_EVENT
+    if META_CONTROLLER_STOP_EVENT is not None:
+        META_CONTROLLER_STOP_EVENT.set()
+    if META_CONTROLLER_TASK is not None:
+        META_CONTROLLER_TASK.cancel()
+        try:
+            await META_CONTROLLER_TASK
+        except asyncio.CancelledError:
+            pass
+    META_CONTROLLER_TASK = None
+    META_CONTROLLER_STOP_EVENT = None
 
 
 class Doc(BaseModel):

--- a/logos/meta/__init__.py
+++ b/logos/meta/__init__.py
@@ -1,0 +1,6 @@
+"""LOGOS meta-controller package."""
+
+from .activation import ActivationGraph, WeightedEdge
+from .controller import MetaController
+
+__all__ = ["ActivationGraph", "MetaController", "WeightedEdge"]

--- a/logos/meta/activation.py
+++ b/logos/meta/activation.py
@@ -1,0 +1,109 @@
+"""Activation graph and deterministic propagation for meta-controller routing."""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WeightedEdge:
+    source: str
+    target: str
+    weight: float
+
+
+class ActivationGraph:
+    """Directed weighted graph used to compute module activation scores."""
+
+    def __init__(
+        self,
+        *,
+        edges: list[WeightedEdge] | None = None,
+        base_activation: Mapping[str, float] | None = None,
+        damping: float = 0.85,
+        propagation_steps: int = 2,
+        seed: int = 7,
+        noise_scale: float = 0.0,
+    ) -> None:
+        self._edges = list(edges or [])
+        self._base_activation = dict(base_activation or {})
+        self._damping = float(damping)
+        self._propagation_steps = max(0, int(propagation_steps))
+        self._random = random.Random(seed)
+        self._noise_scale = max(0.0, float(noise_scale))
+
+    @property
+    def module_names(self) -> set[str]:
+        names = set(self._base_activation.keys())
+        for edge in self._edges:
+            names.add(edge.source)
+            names.add(edge.target)
+        return names
+
+    def inject(self, initial_activation: Mapping[str, float] | None = None) -> dict[str, float]:
+        activation = dict(self._base_activation)
+        for module, value in (initial_activation or {}).items():
+            activation[module] = activation.get(module, 0.0) + float(value)
+
+        for _ in range(self._propagation_steps):
+            propagated = dict(activation)
+            for edge in self._edges:
+                source_value = activation.get(edge.source, 0.0)
+                propagated[edge.target] = propagated.get(edge.target, 0.0) + source_value * edge.weight
+
+            for module in list(propagated.keys()):
+                value = propagated[module] * self._damping
+                if self._noise_scale > 0:
+                    value += self._random.uniform(-self._noise_scale, self._noise_scale)
+                propagated[module] = min(1.0, max(0.0, value))
+            activation = propagated
+
+        return activation
+
+
+def build_activation_graph(config: Mapping[str, object]) -> ActivationGraph:
+    edges_raw = config.get("edges", []) if isinstance(config, Mapping) else []
+    base_activation = config.get("base_activation", {}) if isinstance(config, Mapping) else {}
+
+    edges: list[WeightedEdge] = []
+    for edge in edges_raw if isinstance(edges_raw, list) else []:
+        if not isinstance(edge, Mapping):
+            continue
+        source = str(edge.get("from", "")).strip()
+        target = str(edge.get("to", "")).strip()
+        if not source or not target:
+            continue
+        edges.append(WeightedEdge(source=source, target=target, weight=float(edge.get("weight", 0.0))))
+
+    return ActivationGraph(
+        edges=edges,
+        base_activation={str(k): float(v) for k, v in (base_activation.items() if isinstance(base_activation, Mapping) else [])},
+        damping=float(config.get("damping", 0.85)) if isinstance(config, Mapping) else 0.85,
+        propagation_steps=int(config.get("propagation_steps", 2)) if isinstance(config, Mapping) else 2,
+        seed=int(config.get("seed", 7)) if isinstance(config, Mapping) else 7,
+        noise_scale=float(config.get("noise_scale", 0.0)) if isinstance(config, Mapping) else 0.0,
+    )
+
+
+def aggregate_event_injection(
+    *,
+    event_type: str,
+    event_injection: Mapping[str, object] | None,
+) -> dict[str, float]:
+    """Build per-module activation injection from config for an event type."""
+
+    if not isinstance(event_injection, Mapping):
+        return {}
+
+    merged: dict[str, float] = defaultdict(float)
+    wildcard = event_injection.get("*")
+    for group in (wildcard, event_injection.get(event_type)):
+        if not isinstance(group, Mapping):
+            continue
+        for module_name, value in group.items():
+            merged[str(module_name)] += float(value)
+
+    return dict(merged)

--- a/logos/meta/controller.py
+++ b/logos/meta/controller.py
@@ -1,0 +1,216 @@
+"""Meta-controller orchestration for activation-driven module routing."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from logos.events.bus import EventBus
+from logos.events.types import EventEnvelope
+from logos.knowledgebase.store import DEFAULT_BASE_PATH
+from logos.meta.activation import aggregate_event_injection, build_activation_graph
+from logos.meta.models import ModuleContext, ModuleProtocol, Suggestion
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG_PATH = DEFAULT_BASE_PATH / "rules" / "meta_controller.yml"
+
+
+class MetaController:
+    """Consumes EventBus events and routes activation across configured modules."""
+
+    def __init__(
+        self,
+        event_bus: EventBus,
+        *,
+        config_path: Path | str | None = None,
+    ) -> None:
+        self.event_bus = event_bus
+        self.config_path = Path(config_path) if config_path else DEFAULT_CONFIG_PATH
+        self._config = self._load_config(self.config_path)
+        self.mode = str(self._config.get("mode", "shadow")).strip().lower() or "shadow"
+        self.loop_mode = str(
+            self._config.get("experimentation", {}).get("learning_loop_mode", "unified")
+        ).strip().lower()
+        self.activation_threshold = float(self._config.get("activation_threshold", 0.45))
+        self.allowed_active_pipelines = set(self._config.get("active_allowlist", {}).get("pipelines", []) or [])
+        self.allowed_active_modules = set(self._config.get("active_allowlist", {}).get("modules", []) or [])
+        self._event_injection = self._config.get("event_injection", {})
+        self.activation_graph = build_activation_graph(self._config.get("activation_graph", {}))
+        self.modules = self._build_modules()
+
+    @staticmethod
+    def is_enabled() -> bool:
+        return os.getenv("LOGOS_META_CONTROLLER", "1").strip() not in {"0", "false", "False"}
+
+    def _load_config(self, path: Path) -> dict[str, Any]:
+        if not path.exists():
+            logger.info("meta_controller_config_missing", extra={"path": str(path)})
+            return {}
+        with path.open("r", encoding="utf-8") as handle:
+            loaded = yaml.safe_load(handle) or {}
+        if not isinstance(loaded, dict):
+            return {}
+        return loaded
+
+    def _build_modules(self) -> dict[str, ModuleProtocol]:
+        return {
+            "module.belief_prior_adjuster": self._belief_prior_adjuster,
+            "module.ontology_proposal_summariser": self._ontology_proposal_summariser,
+            "module.learning_signal_router": self._learning_signal_router,
+        }
+
+    def _belief_prior_adjuster(
+        self,
+        event: EventEnvelope,
+        context: ModuleContext,
+    ) -> tuple[list[EventEnvelope], list[Suggestion]]:
+        confidence = max(0.1, min(1.0, context.activation))
+        return (
+            [],
+            [
+                Suggestion(
+                    suggestion_type="logos.suggestion.belief_prior_adjustment",
+                    confidence=confidence,
+                    payload={
+                        "event_type": event.event_type,
+                        "recommended_adjustment": round((context.activation - 0.5) * 0.4, 3),
+                        "learning_loop_mode": context.event_loop_mode,
+                    },
+                )
+            ],
+        )
+
+    def _ontology_proposal_summariser(
+        self,
+        event: EventEnvelope,
+        context: ModuleContext,
+    ) -> tuple[list[EventEnvelope], list[Suggestion]]:
+        concepts = event.payload.get("candidate_concepts", []) if isinstance(event.payload, dict) else []
+        candidate_count = len(concepts) if isinstance(concepts, list) else 0
+        return (
+            [],
+            [
+                Suggestion(
+                    suggestion_type="logos.suggestion.ontology_proposal_summary",
+                    confidence=max(0.1, min(1.0, context.activation)),
+                    payload={
+                        "event_type": event.event_type,
+                        "candidate_count": candidate_count,
+                        "summary": "meta-controller suggests ontology proposal review",
+                    },
+                )
+            ],
+        )
+
+    def _learning_signal_router(
+        self,
+        event: EventEnvelope,
+        context: ModuleContext,
+    ) -> tuple[list[EventEnvelope], list[Suggestion]]:
+        candidate_signals = []
+        if isinstance(event.payload, dict):
+            for key in ("feedback", "scores", "signals"):
+                value = event.payload.get(key)
+                if value is not None:
+                    candidate_signals.append(key)
+
+        return (
+            [],
+            [
+                Suggestion(
+                    suggestion_type="logos.suggestion.learning_signal_route",
+                    confidence=max(0.1, min(1.0, context.activation)),
+                    payload={
+                        "event_type": event.event_type,
+                        "signals": candidate_signals,
+                        "persistence_tier": "mid_term" if context.activation < 0.75 else "long_term_candidate",
+                    },
+                )
+            ],
+        )
+
+    def _publish_suggestion(self, suggestion: Suggestion, *, source_event: EventEnvelope) -> None:
+        envelope = EventEnvelope(
+            event_type=suggestion.suggestion_type,
+            producer="logos.meta.controller",
+            correlation_id=source_event.correlation_id or source_event.event_id,
+            causation_id=source_event.event_id,
+            confidence=suggestion.confidence,
+            provenance={
+                "component": "meta_controller",
+                "mode": self.mode,
+            },
+            payload=suggestion.payload,
+        )
+        self.event_bus.publish(envelope)
+
+    def _publish_if_allowed(self, event: EventEnvelope) -> None:
+        if self.mode == "shadow":
+            if event.event_type.startswith("logos.suggestion."):
+                self.event_bus.publish(event)
+            return
+
+        if event.event_type.startswith("logos.suggestion."):
+            self.event_bus.publish(event)
+            return
+
+        target_pipeline = event.payload.get("pipeline_id") if isinstance(event.payload, dict) else None
+        target_module = event.payload.get("module_name") if isinstance(event.payload, dict) else None
+        if target_pipeline and target_pipeline in self.allowed_active_pipelines:
+            self.event_bus.publish(event)
+            return
+        if target_module and target_module in self.allowed_active_modules:
+            self.event_bus.publish(event)
+
+    def process_event(self, event: EventEnvelope) -> list[str]:
+        if event.producer == "logos.meta.controller":
+            return []
+
+        injection = aggregate_event_injection(
+            event_type=event.event_type,
+            event_injection=self._event_injection,
+        )
+        activations = self.activation_graph.inject(injection)
+        ran_modules: list[str] = []
+
+        for module_name, module in self.modules.items():
+            activation = activations.get(module_name, 0.0)
+            if activation < self.activation_threshold:
+                continue
+
+            ran_modules.append(module_name)
+            context = ModuleContext(
+                activation=activation,
+                mode=self.mode,
+                event_loop_mode=self.loop_mode,
+                metadata={"source_event_type": event.event_type},
+            )
+            events_out, suggestions_out = module(event, context)
+            for suggestion in suggestions_out:
+                self._publish_suggestion(suggestion, source_event=event)
+            for event_out in events_out:
+                self._publish_if_allowed(event_out)
+
+        return ran_modules
+
+    async def run_forever(self, stop_event: asyncio.Event | None = None) -> None:
+        stop_event = stop_event or asyncio.Event()
+        stream = self.event_bus.subscribe()
+        try:
+            while not stop_event.is_set():
+                try:
+                    event = await asyncio.wait_for(anext(stream), timeout=0.2)
+                except asyncio.TimeoutError:
+                    continue
+                self.process_event(event)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            await stream.aclose()

--- a/logos/meta/models.py
+++ b/logos/meta/models.py
@@ -1,0 +1,62 @@
+"""Models and interfaces for LOGOS meta-controller orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from logos.events.types import EventEnvelope
+
+
+class ModuleContext(BaseModel):
+    """Execution context shared with meta modules."""
+
+    model_config = ConfigDict(extra="allow")
+
+    activation: float = Field(default=0.0, ge=0.0)
+    mode: str = Field(default="shadow")
+    event_loop_mode: str = Field(default="unified")
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class Suggestion(BaseModel):
+    """Suggestion output from a module; becomes logos.suggestion.* event(s)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    suggestion_type: str = Field(min_length=1)
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class ModuleOutput(BaseModel):
+    """Structured outputs from a single module invocation."""
+
+    events_out: list[EventEnvelope] = Field(default_factory=list)
+    suggestions_out: list[Suggestion] = Field(default_factory=list)
+
+
+class ModuleProtocol(Protocol):
+    """Meta module contract: (event, context) -> (events_out, suggestions_out)."""
+
+    name: str
+
+    def __call__(
+        self,
+        event: EventEnvelope,
+        context: ModuleContext,
+    ) -> tuple[list[EventEnvelope], list[Suggestion]]:
+        ...
+
+
+def metadata_with_default(
+    metadata: Mapping[str, Any] | None,
+    *,
+    defaults: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = dict(defaults or {})
+    if metadata:
+        payload.update(dict(metadata))
+    return payload

--- a/tests/test_activation_routing.py
+++ b/tests/test_activation_routing.py
@@ -1,0 +1,100 @@
+import pathlib
+import sys
+
+import asyncio
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from logos.events.bus import InMemoryEventBus
+from logos.events.types import EventEnvelope
+from logos.meta.activation import ActivationGraph, WeightedEdge
+from logos.meta.controller import MetaController
+
+
+@pytest.mark.asyncio
+async def test_activation_propagation_is_deterministic_for_fixed_seed(tmp_path) -> None:
+    graph = ActivationGraph(
+        edges=[
+            WeightedEdge("module.a", "module.b", 0.5),
+            WeightedEdge("module.b", "module.c", 0.4),
+        ],
+        base_activation={"module.a": 0.2},
+        seed=17,
+        propagation_steps=3,
+        noise_scale=0.0,
+    )
+
+    first = graph.inject({"module.a": 0.7})
+    second = graph.inject({"module.a": 0.7})
+
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_modules_run_only_when_activation_meets_threshold(tmp_path) -> None:
+    config = tmp_path / "meta.yml"
+    config.write_text(
+        """
+mode: shadow
+activation_threshold: 0.6
+activation_graph:
+  seed: 11
+  damping: 1.0
+  propagation_steps: 1
+  base_activation:
+    module.belief_prior_adjuster: 0.1
+event_injection:
+  logos.test.trigger:
+    module.belief_prior_adjuster: 0.3
+""",
+        encoding="utf-8",
+    )
+
+    bus = InMemoryEventBus()
+    controller = MetaController(bus, config_path=config)
+    event = EventEnvelope(event_type="logos.test.trigger", producer="tests")
+
+    ran = controller.process_event(event)
+
+    assert ran == []
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_emits_suggestions_not_projections(tmp_path) -> None:
+    config = tmp_path / "meta.yml"
+    config.write_text(
+        """
+mode: shadow
+activation_threshold: 0.1
+activation_graph:
+  seed: 3
+  damping: 1.0
+  propagation_steps: 0
+  base_activation:
+    module.belief_prior_adjuster: 0.2
+event_injection:
+  logos.test.input:
+    module.belief_prior_adjuster: 0.5
+""",
+        encoding="utf-8",
+    )
+
+    bus = InMemoryEventBus()
+    controller = MetaController(bus, config_path=config)
+    stream = bus.subscribe()
+
+    first = asyncio.create_task(asyncio.wait_for(anext(stream), timeout=1.0))
+    await asyncio.sleep(0)
+    controller.process_event(EventEnvelope(event_type="logos.test.input", producer="tests"))
+
+    suggestion_event = await first
+
+    assert suggestion_event.event_type.startswith("logos.suggestion.")
+    assert suggestion_event.producer == "logos.meta.controller"
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(anext(stream), timeout=0.05)
+
+    await stream.aclose()


### PR DESCRIPTION
### Motivation
- Provide a safe, configurable meta-controller to experiment with learning loops and non-linear activation routing while defaulting to a no-side-effects SHADOW MODE to avoid destabilising LOGOS. 
- Enable activation-driven selection and routing of modules via a seeded, deterministic activation graph and event-based injection so experiments are reproducible and controlled. 
- Make behaviour data-driven via the knowledgebase so learning-loop mode, thresholds, allowlists and graph topology can be tuned without code changes. 

### Description
- Add a new `logos.meta` package with `models.py` (module context, `Suggestion`, `ModuleProtocol`), `activation.py` (`ActivationGraph`, `WeightedEdge`, injection helpers) and `controller.py` (`MetaController`) implementing activation-driven routing. 
- Implement initial modules inside the controller: `module.belief_prior_adjuster`, `module.ontology_proposal_summariser`, and `module.learning_signal_router`, and ensure suggestions are emitted as `logos.suggestion.*` events. 
- Add a knowledgebase config at `logos/knowledgebase/rules/meta_controller.yml` controlling `mode`, activation graph topology/seed/propagation, `event_injection`, `activation_threshold`, `active_allowlist`, and the `experimentation.learning_loop_mode` switch (`unified` vs `separate`). 
- Wire lazy instantiation in `logos/app_state.py` via `get_meta_controller()` (respecting `LOGOS_META_CONTROLLER=0` to disable) and start/stop a background controller task in FastAPI lifecycle handlers in `logos/main.py`. 

### Testing
- Added `tests/test_activation_routing.py` which asserts deterministic propagation with a fixed seed, module gating by `activation_threshold`, and shadow-mode suggestion-only behaviour. 
- Ran `pytest -q tests/test_activation_routing.py tests/test_event_bus_inmemory.py` and all tests passed (`6 passed`). 
- No tests depend on external services; the changes preserve knowledgebase-driven configuration and lazy startup so production side-effects are avoided by default.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c619aa61948347a80b840cf0c3204a)