### PR TITLE
Add GitHub Actions CI, lint/type steps, and schema stability regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Type checks (mypy, optional)
+        run: |
+          if command -v mypy >/dev/null 2>&1; then
+            mypy logos
+          else
+            echo "mypy not installed; skipping optional type-check step"
+          fi
+
+      - name: Run test suite
+        run: PYTHONPATH=. pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,10 @@ description = "LOGOS Cognitive Engine and Stakeholder Engagement MVP"
 authors = [
   { name = "Lachlan Robertson", email = "lachlanrobertson@iinet.net.au" }
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ pytest==8.4.1
 pytest-asyncio==0.24.0
 pytest-mock==3.14.0
 ruff==0.12.7
+
+# Optional dependency for Redis Streams event bus backend (LOGOS_EVENT_BUS_BACKEND=redis_streams).
+redis==5.1.1

--- a/tests/test_belief_schema_stability.py
+++ b/tests/test_belief_schema_stability.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+
+from logos.contradictions.engine import load_contradiction_rules
+from logos.information.models import Belief
+
+
+def test_belief_json_schema_snapshot_stability() -> None:
+    expected_schema = {
+        "$defs": {
+            "BeliefStatement": {
+                "additionalProperties": True,
+                "description": "Structured subject-predicate-object statement.",
+                "properties": {
+                    "object": {"$ref": "#/$defs/BeliefTerm"},
+                    "predicate": {"title": "Predicate", "type": "string"},
+                    "subject": {"$ref": "#/$defs/BeliefTerm"},
+                },
+                "required": ["subject", "predicate", "object"],
+                "title": "BeliefStatement",
+                "type": "object",
+            },
+            "BeliefStatus": {
+                "enum": ["candidate", "supported", "contested", "rejected"],
+                "title": "BeliefStatus",
+                "type": "string",
+            },
+            "BeliefTerm": {
+                "additionalProperties": True,
+                "description": "Term in a belief statement.",
+                "properties": {
+                    "label": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Label",
+                    },
+                    "ref": {"title": "Ref", "type": "string"},
+                    "value": {"anyOf": [{}, {"type": "null"}], "default": None, "title": "Value"},
+                },
+                "required": ["ref"],
+                "title": "BeliefTerm",
+                "type": "object",
+            },
+            "Polarity": {
+                "enum": ["positive", "negative", "unknown"],
+                "title": "Polarity",
+                "type": "string",
+            },
+            "Provenance": {
+                "additionalProperties": True,
+                "description": "Source and traceability metadata shared by InformationObjects and Beliefs.",
+                "properties": {
+                    "extracted_at": {"format": "date-time", "title": "Extracted At", "type": "string"},
+                    "metadata": {"title": "Metadata", "type": "object"},
+                    "pipeline_id": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Pipeline Id",
+                    },
+                    "source_type": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Source Type",
+                    },
+                    "source_uri": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Source Uri",
+                    },
+                    "supporting_event_ids": {
+                        "items": {"type": "string"},
+                        "title": "Supporting Event Ids",
+                        "type": "array",
+                    },
+                },
+                "title": "Provenance",
+                "type": "object",
+            },
+        },
+        "additionalProperties": True,
+        "description": "Hypothesis-level assertion with confidence and provenance.",
+        "properties": {
+            "confidence": {"default": 0.5, "title": "Confidence", "type": "number"},
+            "id": {"title": "Id", "type": "string"},
+            "metadata": {"title": "Metadata", "type": "object"},
+            "polarity": {"$ref": "#/$defs/Polarity", "default": "unknown"},
+            "provenance": {"$ref": "#/$defs/Provenance"},
+            "statement": {"$ref": "#/$defs/BeliefStatement"},
+            "status": {"$ref": "#/$defs/BeliefStatus", "default": "candidate"},
+        },
+        "required": ["id", "statement"],
+        "title": "Belief",
+        "type": "object",
+    }
+
+    assert Belief.model_json_schema() == expected_schema
+
+
+def test_contradiction_rules_parsing_contract() -> None:
+    rules = load_contradiction_rules(Path("logos/knowledgebase/rules/contradictions.yml"))
+
+    assert any(item.predicate == "OWNS" and item.cardinality == 1 for item in rules.hard_constraints)
+    assert any(item.predicate == "WORKS_WITH" for item in rules.soft_constraints)
+    assert any(item.predicate == "OWNS" and item.overlap_conflict for item in rules.temporal_rules)
+    assert any(item.get("predicate") == "STATE" for item in rules.paradox_allowlist)

--- a/tests/test_event_schema_stability.py
+++ b/tests/test_event_schema_stability.py
@@ -1,0 +1,46 @@
+import json
+
+from logos.events.types import EventEnvelope
+
+
+def test_event_envelope_json_schema_snapshot_stability() -> None:
+    expected_schema = {
+        "additionalProperties": True,
+        "description": "Standard event envelope shared by event bus backends and APIs.",
+        "properties": {
+            "causation_id": {
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+                "default": None,
+                "title": "Causation Id",
+            },
+            "confidence": {
+                "anyOf": [{"maximum": 1.0, "minimum": 0.0, "type": "number"}, {"type": "null"}],
+                "default": None,
+                "title": "Confidence",
+            },
+            "correlation_id": {
+                "anyOf": [{"type": "string"}, {"type": "null"}],
+                "default": None,
+                "title": "Correlation Id",
+            },
+            "event_id": {"title": "Event Id", "type": "string"},
+            "event_type": {"minLength": 1, "title": "Event Type", "type": "string"},
+            "occurred_at": {"format": "date-time", "title": "Occurred At", "type": "string"},
+            "payload": {"title": "Payload", "type": "object"},
+            "producer": {"minLength": 1, "title": "Producer", "type": "string"},
+            "provenance": {"title": "Provenance", "type": "object"},
+            "schema_version": {"default": "1.0", "title": "Schema Version", "type": "string"},
+        },
+        "required": ["event_type", "producer"],
+        "title": "EventEnvelope",
+        "type": "object",
+    }
+
+    assert EventEnvelope.model_json_schema() == expected_schema
+
+
+def test_event_envelope_schema_is_json_serializable() -> None:
+    schema = EventEnvelope.model_json_schema()
+    serialized = json.dumps(schema, sort_keys=True)
+
+    assert "EventEnvelope" in serialized


### PR DESCRIPTION
### Motivation
- Provide automated CI guardrails to prevent schema and policy regressions as the LOGOS architecture evolves. 
- Catch breaking changes to the event envelope and belief models early to preserve replay/projection compatibility. 
- Verify contradiction rule YAML parsing so knowledgebase-driven policies remain loadable and structurally compatible.

### Description
- Add a GitHub Actions workflow `.github/workflows/ci.yml` that installs dependencies, runs `ruff`, optionally runs `mypy` if present, and executes tests across Python 3.11 and 3.12 using an editable install so runtime imports work under CI. 
- Add `tests/test_event_schema_stability.py` which snapshots the `EventEnvelope` JSON Schema and asserts JSON-serializability. 
- Add `tests/test_belief_schema_stability.py` which snapshots the `Belief` JSON Schema and asserts the contradiction rules YAML is parseable and contains key predicates/temporal rules. 
- Update `pyproject.toml` to require Python `>=3.11` and add broader classifiers, and document the optional Redis dependency in `requirements.txt` for the Redis Streams event-bus backend.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_event_schema_stability.py tests/test_belief_schema_stability.py` and all tests passed (`4 passed`).
- Ran `PYTHONPATH=. ruff check tests/test_event_schema_stability.py tests/test_belief_schema_stability.py` and the lint checks passed.
- Note: an initial `pytest` run without `PYTHONPATH=.` failed import collection due to module discovery; CI installs the package editable and runs tests with `PYTHONPATH=.`, and the workflow includes the same install/run steps to avoid this failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c61c269a3c834787aece310212280f)